### PR TITLE
App Search connectivity

### DIFF
--- a/docs/docs/base-ui-setup.md
+++ b/docs/docs/base-ui-setup.md
@@ -15,7 +15,7 @@ Also see [Create React App](https://searchkit.co/docs/examples/create-react-app)
 
 First we need to setup Apollo client. In this guide we will be using [nextjs](https://nextjs.org/) & [withApollo HOC](https://github.com/lfades/next-with-apollo)
 
-We add the @apollo/client & next-with-apollo dependencies via yarn
+We add the @apollo/client, next-with-apollo, and graphql dependencies via yarn
 
 ```yarn add next-with-apollo @apollo/client graphql```
 

--- a/docs/docs/base-ui-setup.md
+++ b/docs/docs/base-ui-setup.md
@@ -72,7 +72,7 @@ const Index = () => {
   return <>
     {data.results.hits.items.map((item) => {
       return (
-        <div>hit id: {item.id}</div>
+        <div key={item.id}>hit id: {item.id}</div>
       )
     })}
   </>;
@@ -101,11 +101,10 @@ then update the root page to use the searchkit HOC
 import { gql, useQuery } from '@apollo/client';
 import { useSearchkitVariables, withSearchkit } from '@searchkit/client'
 import withApollo from '../lib/withApollo';
-import { useState } from 'react'
 
 const QUERY = gql`
     query resultSet($query: String, $filters: [SKFiltersSet], $page: SKPageInput) {
-      results(query: $query, filters: $filters) {
+      results(query: $query, filters: $filters, page: $page) {
         hits {
           items {
             id
@@ -125,7 +124,7 @@ const Index = () => {
   return <>
     {data.results.hits.items.map((item) => {
       return (
-        <div>hit id: {item.id}</div>
+        <div key={item.id}>hit id: {item.id}</div>
       )
     })}
   </>;

--- a/docs/docs/base-ui-setup.md
+++ b/docs/docs/base-ui-setup.md
@@ -17,7 +17,7 @@ First we need to setup Apollo client. In this guide we will be using [nextjs](ht
 
 We add the @apollo/client & next-with-apollo dependencies via yarn
 
-```yarn add next-with-apollo @apollo/client```
+```yarn add next-with-apollo @apollo/client graphql```
 
 Then we configure apollo with next.
 

--- a/docs/docs/ui-setup-eui.md
+++ b/docs/docs/ui-setup-eui.md
@@ -47,12 +47,11 @@ import {
   EuiPageSideBar,
   EuiTitle,
   EuiHorizontalRule,
-  EuiButtonGroup,
   EuiFlexGroup,
   EuiFlexItem
 } from '@elastic/eui'
 
-const query = gql`
+const QUERY = gql`
 query resultSet($query: String, $filters: [SKFiltersSet], $page: SKPageInput, $sortBy: String) {
     results(query: $query, filters: $filters) {
       summary {

--- a/docs/docs/ui-setup-eui.md
+++ b/docs/docs/ui-setup-eui.md
@@ -202,7 +202,7 @@ export default withApollo(withSearchkit(Index));
 ```
 and add EUI CSS globally via adding the css file to pages/_app.js
 
-```
+```javascript
 import '@elastic/eui/dist/eui_theme_light.css'
 
 function MyApp({ Component, pageProps }) {

--- a/packages/searchkit-schema/package.json
+++ b/packages/searchkit-schema/package.json
@@ -30,6 +30,7 @@
     "test": "NODE_ENV=test jest --runInBand --forceExit --detectOpenHandles"
   },
   "dependencies": {
+    "@elastic/app-search-node": "^7.14.0",
     "@elastic/elasticsearch": "^7.9.1",
     "agentkeepalive": "^4.1.3",
     "dataloader": "^2.0.0",

--- a/packages/searchkit-schema/src/core/ASToESResponseAdapter.ts
+++ b/packages/searchkit-schema/src/core/ASToESResponseAdapter.ts
@@ -1,0 +1,36 @@
+export const ASToESResponseAdapter = (asResponse) => {
+  const esResponse = {
+    hits: {
+      total: {
+        value: asResponse.meta.page.total_results
+      },
+      hits: asResponse.results.map((result) => ({
+        _id: result._meta.id,
+        _score: result._meta.score,
+        _index: result._meta.engine,
+        _source: Object.entries(result).reduce((acc, [key, value]) => {
+          if (key === '_meta') return acc
+          return {
+            ...acc,
+            [key]: value.raw
+          }
+        }, {})
+      }))
+    },
+    aggregations: {
+      facet_bucket_all: Object.entries(asResponse.facets).reduce(
+        (p, [k, v]) => ({
+          ...p,
+          [k]: {
+            buckets: v[0].data.map(d => ({
+              key: d.value,
+              doc_count: d.count
+            }))
+          }
+        }),
+        {}
+      )
+    }
+  }
+  return esResponse
+}

--- a/packages/searchkit-schema/src/core/ESToASRequestAdapter.ts
+++ b/packages/searchkit-schema/src/core/ESToASRequestAdapter.ts
@@ -6,6 +6,20 @@ export const ESToASRequestAdapter = (esRequest) => ({
       size: esRequest.size,
       current: Math.ceil((esRequest.from + 1) / 10)
     },
+    filters: {
+      all: esRequest.post_filter?.bool?.must?.map((postFilter) => ({
+        any: [
+          Object.entries(postFilter.bool.must[0].term).reduce(
+            (p, [k, v]) => ({
+              ...p,
+              [k.split('.')[0]]: v
+            }),
+            {}
+          )
+        ]
+      }))
+    },
+
     facets: Object.entries(esRequest?.aggs?.facet_bucket_all?.aggs || {}).reduce(
       (acc, [key, value]) => ({
         ...acc,
@@ -19,5 +33,5 @@ export const ESToASRequestAdapter = (esRequest) => ({
       }),
       {}
     )
-  },
+  }
 })

--- a/packages/searchkit-schema/src/core/ESToASRequestAdapter.ts
+++ b/packages/searchkit-schema/src/core/ESToASRequestAdapter.ts
@@ -8,15 +8,15 @@ export const ESToASRequestAdapter = (esRequest) => ({
     },
     filters: {
       all: esRequest.post_filter?.bool?.must?.map((postFilter) => ({
-        any: [
-          Object.entries(postFilter.bool.must[0].term).reduce(
+        all: postFilter.bool.must.map((must) =>
+          Object.entries(must.term).reduce(
             (p, [k, v]) => ({
               ...p,
               [k.split('.')[0]]: v
             }),
             {}
           )
-        ]
+        )
       }))
     },
 

--- a/packages/searchkit-schema/src/core/ESToASRequestAdapter.ts
+++ b/packages/searchkit-schema/src/core/ESToASRequestAdapter.ts
@@ -1,0 +1,23 @@
+export const ESToASRequestAdapter = (esRequest) => ({
+  query: esRequest?.query?.bool?.must[0].multi_match?.query || '',
+  options: {
+    sort: typeof esRequest.sort === 'string' ? [{ [esRequest.sort]: 'desc' }] : esRequest.sort,
+    page: {
+      size: esRequest.size,
+      current: Math.ceil((esRequest.from + 1) / 10)
+    },
+    facets: Object.entries(esRequest?.aggs?.facet_bucket_all?.aggs || {}).reduce(
+      (acc, [key, value]) => ({
+        ...acc,
+        [value.terms.field.split('.')[0]]: [
+          {
+            type: 'value',
+            name: key,
+            size: value.terms.size
+          }
+        ]
+      }),
+      {}
+    )
+  },
+})

--- a/packages/searchkit-schema/src/core/__tests__/ASToESResponseAdapter.test.ts
+++ b/packages/searchkit-schema/src/core/__tests__/ASToESResponseAdapter.test.ts
@@ -1,0 +1,862 @@
+import { ASToESResponseAdapter } from '../ASToESResponseAdapter'
+
+describe('ASToESResponseAdapter', () => {
+  const asResponse = {
+    meta: {
+      alerts: [],
+      warnings: [],
+      precision: 2,
+      page: {
+        current: 1,
+        total_pages: 73,
+        total_results: 721,
+        size: 10
+      },
+      engine: {
+        name: 'pokemon',
+        type: 'default'
+      },
+      request_id: '1533c4aa-f241-4ce9-b6a8-145a2fb7161e'
+    },
+    results: [
+      {
+        generation: {
+          raw: '6'
+        },
+        image: {
+          raw: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/700.png'
+        },
+        types: {
+          raw: ['Fairy']
+        },
+        hp: {
+          raw: '95'
+        },
+        speed: {
+          raw: '60'
+        },
+        url: {
+          raw: 'https://www.pokemon.com/us/pokedex/700'
+        },
+        number: {
+          raw: '700'
+        },
+        total: {
+          raw: '525'
+        },
+        defenese: {
+          raw: '65'
+        },
+        attack: {
+          raw: '65'
+        },
+        legendary: {
+          raw: 'False'
+        },
+        sp_def: {
+          raw: '130'
+        },
+        name: {
+          raw: 'Sylveon'
+        },
+        sp_attack: {
+          raw: '110'
+        },
+        _meta: {
+          engine: 'pokemon',
+          score: 1,
+          id: '700'
+        },
+        id: {
+          raw: '700'
+        }
+      },
+      {
+        generation: {
+          raw: '6'
+        },
+        image: {
+          raw: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/698.png'
+        },
+        types: {
+          raw: ['Rock', 'Ice']
+        },
+        hp: {
+          raw: '77'
+        },
+        speed: {
+          raw: '46'
+        },
+        url: {
+          raw: 'https://www.pokemon.com/us/pokedex/698'
+        },
+        number: {
+          raw: '698'
+        },
+        total: {
+          raw: '362'
+        },
+        defenese: {
+          raw: '50'
+        },
+        attack: {
+          raw: '59'
+        },
+        legendary: {
+          raw: 'False'
+        },
+        sp_def: {
+          raw: '63'
+        },
+        name: {
+          raw: 'Amaura'
+        },
+        sp_attack: {
+          raw: '67'
+        },
+        _meta: {
+          engine: 'pokemon',
+          score: 1,
+          id: '698'
+        },
+        id: {
+          raw: '698'
+        }
+      },
+      {
+        generation: {
+          raw: '6'
+        },
+        image: {
+          raw: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/696.png'
+        },
+        types: {
+          raw: ['Rock', 'Dragon']
+        },
+        hp: {
+          raw: '58'
+        },
+        speed: {
+          raw: '48'
+        },
+        url: {
+          raw: 'https://www.pokemon.com/us/pokedex/696'
+        },
+        number: {
+          raw: '696'
+        },
+        total: {
+          raw: '362'
+        },
+        defenese: {
+          raw: '77'
+        },
+        attack: {
+          raw: '89'
+        },
+        legendary: {
+          raw: 'False'
+        },
+        sp_def: {
+          raw: '45'
+        },
+        name: {
+          raw: 'Tyrunt'
+        },
+        sp_attack: {
+          raw: '45'
+        },
+        _meta: {
+          engine: 'pokemon',
+          score: 1,
+          id: '696'
+        },
+        id: {
+          raw: '696'
+        }
+      },
+      {
+        generation: {
+          raw: '6'
+        },
+        image: {
+          raw: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/691.png'
+        },
+        types: {
+          raw: ['Poison', 'Dragon']
+        },
+        hp: {
+          raw: '65'
+        },
+        speed: {
+          raw: '44'
+        },
+        url: {
+          raw: 'https://www.pokemon.com/us/pokedex/691'
+        },
+        number: {
+          raw: '691'
+        },
+        total: {
+          raw: '494'
+        },
+        defenese: {
+          raw: '90'
+        },
+        attack: {
+          raw: '75'
+        },
+        legendary: {
+          raw: 'False'
+        },
+        sp_def: {
+          raw: '123'
+        },
+        name: {
+          raw: 'Dragalge'
+        },
+        sp_attack: {
+          raw: '97'
+        },
+        _meta: {
+          engine: 'pokemon',
+          score: 1,
+          id: '691'
+        },
+        id: {
+          raw: '691'
+        }
+      },
+      {
+        generation: {
+          raw: '6'
+        },
+        image: {
+          raw: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/690.png'
+        },
+        types: {
+          raw: ['Poison', 'Water']
+        },
+        hp: {
+          raw: '50'
+        },
+        speed: {
+          raw: '30'
+        },
+        url: {
+          raw: 'https://www.pokemon.com/us/pokedex/690'
+        },
+        number: {
+          raw: '690'
+        },
+        total: {
+          raw: '320'
+        },
+        defenese: {
+          raw: '60'
+        },
+        attack: {
+          raw: '60'
+        },
+        legendary: {
+          raw: 'False'
+        },
+        sp_def: {
+          raw: '60'
+        },
+        name: {
+          raw: 'Skrelp'
+        },
+        sp_attack: {
+          raw: '60'
+        },
+        _meta: {
+          engine: 'pokemon',
+          score: 1,
+          id: '690'
+        },
+        id: {
+          raw: '690'
+        }
+      },
+      {
+        generation: {
+          raw: '6'
+        },
+        image: {
+          raw: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/689.png'
+        },
+        types: {
+          raw: ['Rock', 'Water']
+        },
+        hp: {
+          raw: '72'
+        },
+        speed: {
+          raw: '68'
+        },
+        url: {
+          raw: 'https://www.pokemon.com/us/pokedex/689'
+        },
+        number: {
+          raw: '689'
+        },
+        total: {
+          raw: '500'
+        },
+        defenese: {
+          raw: '115'
+        },
+        attack: {
+          raw: '105'
+        },
+        legendary: {
+          raw: 'False'
+        },
+        sp_def: {
+          raw: '86'
+        },
+        name: {
+          raw: 'Barbaracle'
+        },
+        sp_attack: {
+          raw: '54'
+        },
+        _meta: {
+          engine: 'pokemon',
+          score: 1,
+          id: '689'
+        },
+        id: {
+          raw: '689'
+        }
+      },
+      {
+        generation: {
+          raw: '6'
+        },
+        image: {
+          raw: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/686.png'
+        },
+        types: {
+          raw: ['Dark', 'Psychic']
+        },
+        hp: {
+          raw: '53'
+        },
+        speed: {
+          raw: '45'
+        },
+        url: {
+          raw: 'https://www.pokemon.com/us/pokedex/686'
+        },
+        number: {
+          raw: '686'
+        },
+        total: {
+          raw: '288'
+        },
+        defenese: {
+          raw: '53'
+        },
+        attack: {
+          raw: '54'
+        },
+        legendary: {
+          raw: 'False'
+        },
+        sp_def: {
+          raw: '46'
+        },
+        name: {
+          raw: 'Inkay'
+        },
+        sp_attack: {
+          raw: '37'
+        },
+        _meta: {
+          engine: 'pokemon',
+          score: 1,
+          id: '686'
+        },
+        id: {
+          raw: '686'
+        }
+      },
+      {
+        generation: {
+          raw: '6'
+        },
+        image: {
+          raw: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/684.png'
+        },
+        types: {
+          raw: ['Fairy']
+        },
+        hp: {
+          raw: '62'
+        },
+        speed: {
+          raw: '49'
+        },
+        url: {
+          raw: 'https://www.pokemon.com/us/pokedex/684'
+        },
+        number: {
+          raw: '684'
+        },
+        total: {
+          raw: '341'
+        },
+        defenese: {
+          raw: '66'
+        },
+        attack: {
+          raw: '48'
+        },
+        legendary: {
+          raw: 'False'
+        },
+        sp_def: {
+          raw: '57'
+        },
+        name: {
+          raw: 'Swirlix'
+        },
+        sp_attack: {
+          raw: '59'
+        },
+        _meta: {
+          engine: 'pokemon',
+          score: 1,
+          id: '684'
+        },
+        id: {
+          raw: '684'
+        }
+      },
+      {
+        generation: {
+          raw: '6'
+        },
+        image: {
+          raw: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/679.png'
+        },
+        types: {
+          raw: ['Steel', 'Ghost']
+        },
+        hp: {
+          raw: '45'
+        },
+        speed: {
+          raw: '28'
+        },
+        url: {
+          raw: 'https://www.pokemon.com/us/pokedex/679'
+        },
+        number: {
+          raw: '679'
+        },
+        total: {
+          raw: '325'
+        },
+        defenese: {
+          raw: '100'
+        },
+        attack: {
+          raw: '80'
+        },
+        legendary: {
+          raw: 'False'
+        },
+        sp_def: {
+          raw: '37'
+        },
+        name: {
+          raw: 'Honedge'
+        },
+        sp_attack: {
+          raw: '35'
+        },
+        _meta: {
+          engine: 'pokemon',
+          score: 1,
+          id: '679'
+        },
+        id: {
+          raw: '679'
+        }
+      },
+      {
+        generation: {
+          raw: '6'
+        },
+        image: {
+          raw: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/678.png'
+        },
+        types: {
+          raw: ['Psychic']
+        },
+        hp: {
+          raw: '74'
+        },
+        speed: {
+          raw: '104'
+        },
+        url: {
+          raw: 'https://www.pokemon.com/us/pokedex/678'
+        },
+        number: {
+          raw: '678'
+        },
+        total: {
+          raw: '466'
+        },
+        defenese: {
+          raw: '76'
+        },
+        attack: {
+          raw: '48'
+        },
+        legendary: {
+          raw: 'False'
+        },
+        sp_def: {
+          raw: '81'
+        },
+        name: {
+          raw: 'Meowstic'
+        },
+        sp_attack: {
+          raw: '83'
+        },
+        _meta: {
+          engine: 'pokemon',
+          score: 1,
+          id: '678'
+        },
+        id: {
+          raw: '678'
+        }
+      }
+    ],
+    facets: {
+      legendary: [
+        {
+          type: 'value',
+          name: 'legendary',
+          data: [
+            {
+              value: 'False',
+              count: 675
+            },
+            {
+              value: 'True',
+              count: 46
+            }
+          ]
+        }
+      ],
+      types: [
+        {
+          type: 'value',
+          name: 'types',
+          data: [
+            {
+              value: 'Water',
+              count: 118
+            },
+            {
+              value: 'Normal',
+              count: 97
+            },
+            {
+              value: 'Flying',
+              count: 91
+            },
+            {
+              value: 'Grass',
+              count: 83
+            },
+            {
+              value: 'Psychic',
+              count: 75
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  it('does things', () => {
+    expect(ASToESResponseAdapter(asResponse)).toEqual({
+      hits: {
+        total: {
+          value: 721
+        },
+        hits: [
+          {
+            _score: 1,
+            _id: '700',
+            _index: 'pokemon',
+            _source: {
+              attack: '65',
+              defenese: '65',
+              generation: '6',
+              hp: '95',
+              id: '700',
+              image: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/700.png',
+              legendary: 'False',
+              name: 'Sylveon',
+              number: '700',
+              sp_attack: '110',
+              sp_def: '130',
+              speed: '60',
+              total: '525',
+              types: ['Fairy'],
+              url: 'https://www.pokemon.com/us/pokedex/700'
+            }
+          },
+          {
+            _score: 1,
+            _id: '698',
+            _index: 'pokemon',
+            _source: {
+              attack: '59',
+              defenese: '50',
+              generation: '6',
+              hp: '77',
+              id: '698',
+              image: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/698.png',
+              legendary: 'False',
+              name: 'Amaura',
+              number: '698',
+              sp_attack: '67',
+              sp_def: '63',
+              speed: '46',
+              total: '362',
+              types: ['Rock', 'Ice'],
+              url: 'https://www.pokemon.com/us/pokedex/698'
+            }
+          },
+          {
+            _score: 1,
+            _id: '696',
+            _index: 'pokemon',
+            _source: {
+              attack: '89',
+              defenese: '77',
+              generation: '6',
+              hp: '58',
+              id: '696',
+              image: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/696.png',
+              legendary: 'False',
+              name: 'Tyrunt',
+              number: '696',
+              sp_attack: '45',
+              sp_def: '45',
+              speed: '48',
+              total: '362',
+              types: ['Rock', 'Dragon'],
+              url: 'https://www.pokemon.com/us/pokedex/696'
+            }
+          },
+          {
+            _score: 1,
+            _id: '691',
+            _index: 'pokemon',
+            _source: {
+              attack: '75',
+              defenese: '90',
+              generation: '6',
+              hp: '65',
+              id: '691',
+              image: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/691.png',
+              legendary: 'False',
+              name: 'Dragalge',
+              number: '691',
+              sp_attack: '97',
+              sp_def: '123',
+              speed: '44',
+              total: '494',
+              types: ['Poison', 'Dragon'],
+              url: 'https://www.pokemon.com/us/pokedex/691'
+            }
+          },
+          {
+            _score: 1,
+            _id: '690',
+            _index: 'pokemon',
+            _source: {
+              attack: '60',
+              defenese: '60',
+              generation: '6',
+              hp: '50',
+              id: '690',
+              image: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/690.png',
+              legendary: 'False',
+              name: 'Skrelp',
+              number: '690',
+              sp_attack: '60',
+              sp_def: '60',
+              speed: '30',
+              total: '320',
+              types: ['Poison', 'Water'],
+              url: 'https://www.pokemon.com/us/pokedex/690'
+            }
+          },
+          {
+            _score: 1,
+            _id: '689',
+            _index: 'pokemon',
+            _source: {
+              attack: '105',
+              defenese: '115',
+              generation: '6',
+              hp: '72',
+              id: '689',
+              image: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/689.png',
+              legendary: 'False',
+              name: 'Barbaracle',
+              number: '689',
+              sp_attack: '54',
+              sp_def: '86',
+              speed: '68',
+              total: '500',
+              types: ['Rock', 'Water'],
+              url: 'https://www.pokemon.com/us/pokedex/689'
+            }
+          },
+          {
+            _score: 1,
+            _id: '686',
+            _index: 'pokemon',
+            _source: {
+              attack: '54',
+              defenese: '53',
+              generation: '6',
+              hp: '53',
+              id: '686',
+              image: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/686.png',
+              legendary: 'False',
+              name: 'Inkay',
+              number: '686',
+              sp_attack: '37',
+              sp_def: '46',
+              speed: '45',
+              total: '288',
+              types: ['Dark', 'Psychic'],
+              url: 'https://www.pokemon.com/us/pokedex/686'
+            }
+          },
+          {
+            _score: 1,
+            _id: '684',
+            _index: 'pokemon',
+            _source: {
+              attack: '48',
+              defenese: '66',
+              generation: '6',
+              hp: '62',
+              id: '684',
+              image: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/684.png',
+              legendary: 'False',
+              name: 'Swirlix',
+              number: '684',
+              sp_attack: '59',
+              sp_def: '57',
+              speed: '49',
+              total: '341',
+              types: ['Fairy'],
+              url: 'https://www.pokemon.com/us/pokedex/684'
+            }
+          },
+          {
+            _score: 1,
+            _id: '679',
+            _index: 'pokemon',
+            _source: {
+              attack: '80',
+              defenese: '100',
+              generation: '6',
+              hp: '45',
+              id: '679',
+              image: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/679.png',
+              legendary: 'False',
+              name: 'Honedge',
+              number: '679',
+              sp_attack: '35',
+              sp_def: '37',
+              speed: '28',
+              total: '325',
+              types: ['Steel', 'Ghost'],
+              url: 'https://www.pokemon.com/us/pokedex/679'
+            }
+          },
+          {
+            _score: 1,
+            _id: '678',
+            _index: 'pokemon',
+            _source: {
+              attack: '48',
+              defenese: '76',
+              generation: '6',
+              hp: '74',
+              id: '678',
+              image: 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/678.png',
+              legendary: 'False',
+              name: 'Meowstic',
+              number: '678',
+              sp_attack: '83',
+              sp_def: '81',
+              speed: '104',
+              total: '466',
+              types: ['Psychic'],
+              url: 'https://www.pokemon.com/us/pokedex/678'
+            }
+          }
+        ]
+      },
+      aggregations: {
+        facet_bucket_all: {
+          legendary: {
+            buckets: [
+              {
+                doc_count: 675,
+                key: 'False'
+              },
+              {
+                doc_count: 46,
+                key: 'True'
+              }
+            ]
+          },
+          types: {
+            buckets: [
+              {
+                doc_count: 118,
+                key: 'Water'
+              },
+              {
+                doc_count: 97,
+                key: 'Normal'
+              },
+              {
+                doc_count: 91,
+                key: 'Flying'
+              },
+              {
+                doc_count: 83,
+                key: 'Grass'
+              },
+              {
+                doc_count: 75,
+                key: 'Psychic'
+              }
+            ]
+          }
+        }
+      }
+    })
+  })
+})

--- a/packages/searchkit-schema/src/core/__tests__/ESToASRequestAdapter.test.ts
+++ b/packages/searchkit-schema/src/core/__tests__/ESToASRequestAdapter.test.ts
@@ -2,6 +2,34 @@ import { ESToASRequestAdapter } from '../ESToASRequestAdapter'
 
 describe('ESToASRequestAdapter', () => {
   const esQuery = {
+    post_filter: {
+      bool: {
+        must: [
+          {
+            bool: {
+              must: [
+                {
+                  term: {
+                    'types.keyword': 'Water'
+                  }
+                }
+              ]
+            }
+          },
+          {
+            bool: {
+              must: [
+                {
+                  term: {
+                    legendary: 'False'
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
     query: {
       bool: {
         must: [
@@ -50,6 +78,24 @@ describe('ESToASRequestAdapter', () => {
     expect(ESToASRequestAdapter(esQuery)).toEqual({
       query: 'pikachu',
       options: {
+        filters: {
+          all: [
+            {
+              any: [
+                {
+                  types: 'Water'
+                }
+              ]
+            },
+            {
+              any: [
+                {
+                  legendary: 'False'
+                }
+              ]
+            }
+          ]
+        },
         facets: {
           types: [
             {
@@ -88,6 +134,24 @@ describe('ESToASRequestAdapter', () => {
     ).toEqual({
       query: 'pikachu',
       options: {
+        filters: {
+          all: [
+            {
+              any: [
+                {
+                  types: 'Water'
+                }
+              ]
+            },
+            {
+              any: [
+                {
+                  legendary: 'False'
+                }
+              ]
+            }
+          ]
+        },
         facets: {
           types: [
             {

--- a/packages/searchkit-schema/src/core/__tests__/ESToASRequestAdapter.test.ts
+++ b/packages/searchkit-schema/src/core/__tests__/ESToASRequestAdapter.test.ts
@@ -10,6 +10,11 @@ describe('ESToASRequestAdapter', () => {
               must: [
                 {
                   term: {
+                    'types.keyword': 'Rock'
+                  }
+                },
+                {
+                  term: {
                     'types.keyword': 'Water'
                   }
                 }
@@ -81,14 +86,17 @@ describe('ESToASRequestAdapter', () => {
         filters: {
           all: [
             {
-              any: [
+              all: [
+                {
+                  types: 'Rock'
+                },
                 {
                   types: 'Water'
                 }
               ]
             },
             {
-              any: [
+              all: [
                 {
                   legendary: 'False'
                 }
@@ -137,14 +145,17 @@ describe('ESToASRequestAdapter', () => {
         filters: {
           all: [
             {
-              any: [
+              all: [
+                {
+                  types: 'Rock'
+                },
                 {
                   types: 'Water'
                 }
               ]
             },
             {
-              any: [
+              all: [
                 {
                   legendary: 'False'
                 }

--- a/packages/searchkit-schema/src/core/__tests__/ESToASRequestAdapter.test.ts
+++ b/packages/searchkit-schema/src/core/__tests__/ESToASRequestAdapter.test.ts
@@ -1,0 +1,119 @@
+import { ESToASRequestAdapter } from '../ESToASRequestAdapter'
+
+describe('ESToASRequestAdapter', () => {
+  const esQuery = {
+    query: {
+      bool: {
+        must: [
+          {
+            multi_match: {
+              query: 'pikachu',
+              fields: ['name']
+            }
+          }
+        ]
+      }
+    },
+    sort: [
+      {
+        _score: 'desc'
+      }
+    ],
+    from: 0,
+    size: 10,
+    aggs: {
+      facet_bucket_all: {
+        aggs: {
+          types: {
+            terms: {
+              field: 'types.keyword',
+              size: 5
+            }
+          },
+          legendary: {
+            terms: {
+              field: 'legendary',
+              size: 5
+            }
+          }
+        },
+        filter: {
+          bool: {
+            must: []
+          }
+        }
+      }
+    }
+  }
+
+  it('does things', () => {
+    expect(ESToASRequestAdapter(esQuery)).toEqual({
+      query: 'pikachu',
+      options: {
+        facets: {
+          types: [
+            {
+              type: 'value',
+              name: 'types',
+              size: 5
+            }
+          ],
+          legendary: [
+            {
+              type: 'value',
+              name: 'legendary',
+              size: 5
+            }
+          ]
+        },
+        page: {
+          size: 10,
+          current: 1
+        },
+        sort: [
+          {
+            _score: 'desc'
+          }
+        ]
+      }
+    })
+  })
+
+  it('wraps up sort correctly', () => {
+    expect(
+      ESToASRequestAdapter({
+        ...esQuery,
+        sort: '_score'
+      })
+    ).toEqual({
+      query: 'pikachu',
+      options: {
+        facets: {
+          types: [
+            {
+              type: 'value',
+              name: 'types',
+              size: 5
+            }
+          ],
+          legendary: [
+            {
+              type: 'value',
+              name: 'legendary',
+              size: 5
+            }
+          ]
+        },
+        page: {
+          size: 10,
+          current: 1
+        },
+        sort: [
+          {
+            _score: 'desc'
+          }
+        ]
+      }
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,6 +388,14 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@elastic/app-search-node@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@elastic/app-search-node/-/app-search-node-7.14.0.tgz#d656d6caa9e887c7fc8363915c48a0d105b37101"
+  integrity sha512-hlVKiwvsRZ0aV2Olef32BYZj9X2XRpJ9ALlgeVBEsVa4/gsz00aqIiyQt+JZ02VQaybK0DEIOqOMp2EpmbEJNA==
+  dependencies:
+    jsonwebtoken "^8.1.1"
+    request "^2.81.0"
+
 "@elastic/datemath@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@elastic/datemath/-/datemath-5.0.3.tgz#7baccdab672b9a3ecb7fe8387580670936b58573"
@@ -3044,6 +3052,11 @@ btoa-lite@^1.0.0:
   resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
   integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
+
 buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -4134,6 +4147,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -6855,6 +6875,22 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
+jsonwebtoken@^8.1.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -6872,6 +6908,23 @@ jsprim@^1.2.2:
   dependencies:
     array-includes "^3.1.2"
     object.assign "^4.1.2"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -7034,20 +7087,55 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
 
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -9306,7 +9394,7 @@ replace-ext@1.0.0:
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
   integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
-request@^2.88.0:
+request@^2.81.0, request@^2.88.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==


### PR DESCRIPTION
This PR updates searchkit to work with App Search instead of Elasticsearch.

There's two approaches I could have taken for this:
- Modify searchkit/client to hit the App Search API directly
- Modify searchkit/schema to hit App Search on the backend

I chose the latter.

In a more feature complete scenario, beyond a simple POC, I probably would have taken a different approach. For this, I'm simply converting ES queries to App Search queries before sending them to the server.

![latest (1)](https://user-images.githubusercontent.com/1427475/130289366-aa4ed7c1-1e83-46c6-b278-a3b0fe0944c0.gif)

